### PR TITLE
fix: only announce <Product> Application releases per tag

### DIFF
--- a/scraper_backends/graphql_backend.py
+++ b/scraper_backends/graphql_backend.py
@@ -68,14 +68,33 @@ class GraphQLBackend:
 
     _ALLOWED_TAGS_SET = frozenset(ALLOWED_TAGS)
 
-    # Pre-compiled unwanted patterns to avoid re-allocating on every release
+    # Per-tag allow-list: when a tag is mapped here, only releases whose title
+    # contains ALL of these substrings (case-insensitive) are announced.
+    # The community API tags accessory firmware (Viewport, Cameras, AI Port,
+    # AI Key, AI Horn Speaker, SuperLink, sensors, NVR, etc.) under the same
+    # tag as the main software, so a deny-list is fragile — every new accessory
+    # name has to be added. Requiring "Application" in the title keeps just the
+    # main software release for each product line.
+    TAG_TITLE_INCLUDES: dict[str, tuple[str, ...]] = {
+        "unifi-protect": ("protect", "application"),
+        "unifi-network": ("network", "application"),
+        "unifi-access": ("access", "application"),
+        "unifi-talk": ("talk", "application"),
+        "unifi-drive": ("drive", "application"),
+        "unifi-connect": ("connect", "application"),
+        "unifi-portal": ("portal", "application"),
+    }
+
+    # Fallback deny-list used for tags that don't have an explicit allow-list.
     UNWANTED_PATTERNS = (
         "android",
         "ios",
         "iphone",
         "ipad",
+        "tvos",
         "sfp wizard",
         "ups",
+        "advisory",
     )
 
     def __init__(self, session: aiohttp.ClientSession | None = None) -> None:
@@ -161,32 +180,36 @@ class GraphQLBackend:
             "tag": tag,
         }
 
+    def _is_release_allowed_for_tag(self, release_title: str, tag: str) -> bool:
+        """Return True if release_title (lowercase) is an announceable release for tag.
+
+        Tags with an entry in TAG_TITLE_INCLUDES use a positive allow-list:
+        every required substring must appear in the title. Other tags fall
+        back to the UNWANTED_PATTERNS deny-list.
+        """
+        required = self.TAG_TITLE_INCLUDES.get(tag)
+        if required is not None:
+            return all(token in release_title for token in required)
+        return not any(p in release_title for p in self.UNWANTED_PATTERNS)
+
     def _process_releases_response(self, all_releases: list[dict], tags: list[str]) -> dict[str, dict]:
         """Filter and group releases by tag, returning the latest for each."""
-        releases_by_tag = {}
+        releases_by_tag: dict[str, dict] = {}
         for release_data in all_releases:
             release_tags = release_data.get("tags", [])
             release_title = release_data.get("title", "").lower()
 
-            # Check if this release should be filtered out
-            matched_pattern = next((p for p in self.UNWANTED_PATTERNS if p in release_title), None)
-            if matched_pattern:
-                logging.debug(
-                    "Filtering out release '%s' due to pattern '%s'", release_data.get("title"), matched_pattern
-                )
-                continue
-
-            # Find which of our configured tags this release belongs to
             for tag in tags:
-                if tag in release_tags:
-                    if tag not in releases_by_tag:
-                        releases_by_tag[tag] = release_data
-                    else:
-                        # Keep the most recent (releases are sorted by createdAt DESC)
-                        current_date = releases_by_tag[tag]["createdAt"]
-                        new_date = release_data["createdAt"]
-                        if new_date > current_date:
-                            releases_by_tag[tag] = release_data
+                if tag not in release_tags:
+                    continue
+                if not self._is_release_allowed_for_tag(release_title, tag):
+                    logging.debug(
+                        "Filtering out release '%s' for tag '%s'", release_data.get("title"), tag
+                    )
+                    continue
+                existing = releases_by_tag.get(tag)
+                if existing is None or release_data["createdAt"] > existing["createdAt"]:
+                    releases_by_tag[tag] = release_data
 
         return releases_by_tag
 

--- a/tests/test_graphql_backend.py
+++ b/tests/test_graphql_backend.py
@@ -123,7 +123,7 @@ class TestGraphQLBackendTags(TestGraphQLBackendBase):
                     "items": [
                         {
                             "id": "123",
-                            "title": "Network Release",
+                            "title": "UniFi Network Application",
                             "version": "1.0.0",
                             "slug": "network-release",
                             "tags": ["unifi-network"],
@@ -131,7 +131,7 @@ class TestGraphQLBackendTags(TestGraphQLBackendBase):
                         },
                         {
                             "id": "456",
-                            "title": "Protect Release",
+                            "title": "UniFi Protect Application",
                             "version": "2.0.0",
                             "slug": "protect-release",
                             "tags": ["unifi-protect"],
@@ -234,7 +234,7 @@ class TestGraphQLBackendFiltering(TestGraphQLBackendBase):
             },
             {
                 "id": "456",
-                "title": "UniFi Network",
+                "title": "UniFi Network Application",
                 "version": "2.0.0",
                 "slug": "network-base",
                 "tags": ["unifi-network"],
@@ -250,7 +250,7 @@ class TestGraphQLBackendFiltering(TestGraphQLBackendBase):
 
         # Should only return the base network release, not Android
         self.assertEqual(len(results), 1)
-        self.assertIn("UniFi Network 2.0.0", results[0]["title"])
+        self.assertIn("UniFi Network Application 2.0.0", results[0]["title"])
         self.assertNotIn("Android", results[0]["title"])
 
     @patch("aiohttp.ClientSession")
@@ -283,7 +283,7 @@ class TestGraphQLBackendFiltering(TestGraphQLBackendBase):
             },
             {
                 "id": "101",
-                "title": "UniFi Network",
+                "title": "UniFi Network Application",
                 "version": "2.0.0",
                 "slug": "network-base",
                 "tags": ["unifi-network"],
@@ -299,7 +299,7 @@ class TestGraphQLBackendFiltering(TestGraphQLBackendBase):
 
         # Should only return the base network release
         self.assertEqual(len(results), 1)
-        self.assertIn("UniFi Network 2.0.0", results[0]["title"])
+        self.assertIn("UniFi Network Application 2.0.0", results[0]["title"])
 
     @patch("aiohttp.ClientSession")
     def test_filters_mobile_releases_from_all_tags(self, mock_session_cls: MagicMock) -> None:
@@ -315,7 +315,7 @@ class TestGraphQLBackendFiltering(TestGraphQLBackendBase):
             },
             {
                 "id": "456",
-                "title": "UniFi Protect",
+                "title": "UniFi Protect Application",
                 "version": "2.0.0",
                 "slug": "protect-base",
                 "tags": ["unifi-protect"],
@@ -331,7 +331,7 @@ class TestGraphQLBackendFiltering(TestGraphQLBackendBase):
 
         # Should return only the base protect release, not Android
         self.assertEqual(len(results), 1)
-        self.assertIn("UniFi Protect 2.0.0", results[0]["title"])
+        self.assertIn("UniFi Protect Application 2.0.0", results[0]["title"])
         self.assertNotIn("Android", results[0]["title"])
 
     @patch("aiohttp.ClientSession")
@@ -340,7 +340,7 @@ class TestGraphQLBackendFiltering(TestGraphQLBackendBase):
         releases_data = [
             {
                 "id": "123",
-                "title": "UniFi Network",
+                "title": "UniFi Network Application",
                 "version": "8.0.28",
                 "slug": "network-stable",
                 "tags": ["unifi-network"],
@@ -356,7 +356,7 @@ class TestGraphQLBackendFiltering(TestGraphQLBackendBase):
 
         self.assertEqual(len(results), 1)
         self.assertIn("(GA)", results[0]["title"])
-        self.assertEqual(results[0]["title"], "UniFi Network 8.0.28 (GA)")
+        self.assertEqual(results[0]["title"], "UniFi Network Application 8.0.28 (GA)")
 
     @patch("aiohttp.ClientSession")
     def test_adds_beta_status_to_beta_releases(self, mock_session_cls: MagicMock) -> None:
@@ -364,7 +364,7 @@ class TestGraphQLBackendFiltering(TestGraphQLBackendBase):
         releases_data = [
             {
                 "id": "123",
-                "title": "UniFi Network",
+                "title": "UniFi Network Application",
                 "version": "8.1.0-beta.1",
                 "slug": "network-beta",
                 "tags": ["unifi-network"],
@@ -380,7 +380,7 @@ class TestGraphQLBackendFiltering(TestGraphQLBackendBase):
 
         self.assertEqual(len(results), 1)
         self.assertIn("(Beta)", results[0]["title"])
-        self.assertEqual(results[0]["title"], "UniFi Network 8.1.0-beta.1 (Beta)")
+        self.assertEqual(results[0]["title"], "UniFi Network Application 8.1.0-beta.1 (Beta)")
 
     @patch("aiohttp.ClientSession")
     def test_adds_beta_status_to_rc_releases(self, mock_session_cls: MagicMock) -> None:
@@ -388,7 +388,7 @@ class TestGraphQLBackendFiltering(TestGraphQLBackendBase):
         releases_data = [
             {
                 "id": "123",
-                "title": "UniFi Network",
+                "title": "UniFi Network Application",
                 "version": "8.1.0-rc.1",
                 "slug": "network-rc",
                 "tags": ["unifi-network"],
@@ -404,7 +404,7 @@ class TestGraphQLBackendFiltering(TestGraphQLBackendBase):
 
         self.assertEqual(len(results), 1)
         self.assertIn("(Beta)", results[0]["title"])
-        self.assertEqual(results[0]["title"], "UniFi Network 8.1.0-rc.1 (Beta)")
+        self.assertEqual(results[0]["title"], "UniFi Network Application 8.1.0-rc.1 (Beta)")
 
     @patch("aiohttp.ClientSession")
     def test_detects_beta_in_title(self, mock_session_cls: MagicMock) -> None:
@@ -412,7 +412,7 @@ class TestGraphQLBackendFiltering(TestGraphQLBackendBase):
         releases_data = [
             {
                 "id": "123",
-                "title": "UniFi Network Beta",
+                "title": "UniFi Network Application Beta",
                 "version": "8.1.0",
                 "slug": "network-beta-title",
                 "tags": ["unifi-network"],
@@ -428,6 +428,131 @@ class TestGraphQLBackendFiltering(TestGraphQLBackendBase):
 
         self.assertEqual(len(results), 1)
         self.assertIn("(Beta)", results[0]["title"])
+
+
+class TestGraphQLBackendUnifiProtectAccessoryFiltering(TestGraphQLBackendBase):
+    """Releases tagged unifi-protect include accessory firmware (Viewport,
+    Cameras, AI Port, AI Key, AI Horn Speaker, SuperLink, sensors, NVR, tvOS,
+    iOS/Android apps). Only the main "UniFi Protect Application" release
+    should be announced."""
+
+    def _setup_mock(self, mock_session_cls: MagicMock, releases_data: list) -> None:
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"data": {"releases": {"items": releases_data}}}
+
+        mock_session = mock_session_cls.return_value
+        mock_session.__aenter__.return_value = mock_session
+
+        mock_post_ctx = MagicMock()
+        mock_session.post.return_value = mock_post_ctx
+        mock_post_ctx.__aenter__.return_value = mock_response
+
+    @patch("aiohttp.ClientSession")
+    def test_filters_protect_accessories_and_keeps_application(self, mock_session_cls: MagicMock) -> None:
+        # Modeled on the real API response: accessory firmware is newer than
+        # the application, so the bug surfaces if filtering is not strict.
+        releases_data = [
+            {
+                "id": "1", "title": "UniFi Protect Viewport", "version": "1.4.33",
+                "slug": "viewport", "tags": ["unifi-protect"],
+                "createdAt": "2026-04-27T00:00:00Z",
+            },
+            {
+                "id": "2", "title": "UniFi Protect Cameras", "version": "5.2.92",
+                "slug": "cameras", "tags": ["unifi-protect"],
+                "createdAt": "2026-04-21T00:00:00Z",
+            },
+            {
+                "id": "3", "title": "UniFi Protect SuperLink", "version": "1.10.0",
+                "slug": "superlink", "tags": ["unifi-protect"],
+                "createdAt": "2026-04-21T00:00:00Z",
+            },
+            {
+                "id": "4", "title": "UniFi Protect AI Horn Speaker", "version": "1.3.6",
+                "slug": "ai-horn", "tags": ["unifi-protect"],
+                "createdAt": "2026-04-20T00:00:00Z",
+            },
+            {
+                "id": "5", "title": "UniFi Protect AI Port", "version": "5.1.10",
+                "slug": "ai-port", "tags": ["unifi-protect"],
+                "createdAt": "2026-04-19T00:00:00Z",
+            },
+            {
+                "id": "6", "title": "UniFi Protect AI Key", "version": "2.1.2",
+                "slug": "ai-key", "tags": ["unifi-protect"],
+                "createdAt": "2026-04-18T00:00:00Z",
+            },
+            {
+                "id": "7", "title": "UniFi Protect tvOS", "version": "3.5.0",
+                "slug": "tvos", "tags": ["unifi-protect"],
+                "createdAt": "2026-04-15T00:00:00Z",
+            },
+            {
+                "id": "8", "title": "UniFi Protect SuperLink Glass Break Sensor",
+                "version": "1.1.3", "slug": "glass-break",
+                "tags": ["unifi-protect"], "createdAt": "2026-03-27T00:00:00Z",
+            },
+            {
+                "id": "9", "title": "UniFi Protect Application", "version": "7.0.107",
+                "slug": "protect-app", "tags": ["unifi-protect"],
+                "createdAt": "2026-04-16T00:00:00Z",
+            },
+        ]
+        self._setup_mock(mock_session_cls, releases_data)
+
+        os.environ["TAGS"] = "unifi-protect"
+        backend = GraphQLBackend()
+
+        results = asyncio.run(backend.get_latest_releases())
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["title"], "UniFi Protect Application 7.0.107 (GA)")
+
+    @patch("aiohttp.ClientSession")
+    def test_returns_nothing_when_only_accessories_present(self, mock_session_cls: MagicMock) -> None:
+        releases_data = [
+            {
+                "id": "1", "title": "UniFi Protect Viewport", "version": "1.4.33",
+                "slug": "viewport", "tags": ["unifi-protect"],
+                "createdAt": "2026-04-27T00:00:00Z",
+            },
+        ]
+        self._setup_mock(mock_session_cls, releases_data)
+
+        os.environ["TAGS"] = "unifi-protect"
+        backend = GraphQLBackend()
+
+        results = asyncio.run(backend.get_latest_releases())
+        self.assertEqual(results, [])
+
+    @patch("aiohttp.ClientSession")
+    def test_filters_advisory_and_ups_from_unifi_network(self, mock_session_cls: MagicMock) -> None:
+        releases_data = [
+            {
+                "id": "1", "title": "Security Advisory Bulletin 062", "version": "062",
+                "slug": "advisory-062", "tags": ["unifi-network"],
+                "createdAt": "2026-03-18T00:00:00Z",
+            },
+            {
+                "id": "2", "title": "UniFi UPS", "version": "1.4.24",
+                "slug": "ups", "tags": ["unifi-network"],
+                "createdAt": "2026-03-31T00:00:00Z",
+            },
+            {
+                "id": "3", "title": "UniFi Network Application", "version": "10.3.58",
+                "slug": "network-app", "tags": ["unifi-network"],
+                "createdAt": "2026-04-22T00:00:00Z",
+            },
+        ]
+        self._setup_mock(mock_session_cls, releases_data)
+
+        os.environ["TAGS"] = "unifi-network"
+        backend = GraphQLBackend()
+
+        results = asyncio.run(backend.get_latest_releases())
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["title"], "UniFi Network Application 10.3.58 (GA)")
 
 
 class TestGraphQLBackendDetails(TestGraphQLBackendBase):


### PR DESCRIPTION
## Summary

The bot was announcing accessory firmware (e.g. **UniFi Protect Viewport 1.4.33 (GA)**) that was never on the configured wanted list.

The `unifi-protect` tag on community.ui.com is shared across many sub-products: Application, Viewport, Cameras, SuperLink, AI Horn Speaker, AI Port, AI Key, tvOS, environmental/entry sensors, NVR firmware, etc. The previous filter was a deny-list of just six substrings (`android`, `ios`, `iphone`, `ipad`, `sfp wizard`, `ups`), so anything new slipped through. Whichever accessory was newest displaced the real Protect Application announcement.

## What changed

- New per-tag positive allow-list `TAG_TITLE_INCLUDES` requiring the title contain `"<product>"` and `"application"` for the seven main software tags (`unifi-protect`, `unifi-network`, `unifi-access`, `unifi-talk`, `unifi-drive`, `unifi-connect`, `unifi-portal`).
- Tags without an entry fall back to an extended deny-list — now also drops `tvos` and `advisory` (Security Advisory Bulletins were also leaking through under `unifi-network`).
- New `TestGraphQLBackendUnifiProtectAccessoryFiltering` test class with three regression tests modelled directly on the real API response (Viewport, Cameras, SuperLink, AI Horn Speaker, AI Port, AI Key, tvOS, sensors all present alongside the Application).
- Existing test fixtures updated to use the real "UniFi Network Application" / "UniFi Protect Application" naming.

## Verification

- `uv run pytest tests/` — 77 passed.
- Live smoke test against the real GraphQL API now returns just:
  - `UniFi Network Application 10.3.58 (GA)`
  - `UniFi Protect Application 7.0.107 (GA)`

## Reviewer notes

The allow-list is opinionated: it assumes UniFi's `<Product> Application` naming convention for the main software in each product line. If a future tag uses a different word (e.g. `Console`), it just needs an entry in `TAG_TITLE_INCLUDES`. Tags not in the map keep working via the deny-list fallback.

## Test plan

- [x] `uv run pytest tests/` passes
- [x] Live API call returns only Application releases for `unifi-protect` and `unifi-network`
- [ ] Run the bot for one tick in production and confirm no Viewport / Cameras / SuperLink / AI Port announcements
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/unifi-release-announcer/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
