### PR TITLE
🔒 [security fix] Remove information exposure through debug logs

### DIFF
--- a/scraper_backends/graphql_backend.py
+++ b/scraper_backends/graphql_backend.py
@@ -295,9 +295,6 @@ class GraphQLBackend:
 
             if not all_releases:
                 logging.warning("No releases found in API response")
-                # Full response might contain sensitive data or malicious strings
-                # Only log keys or sanitized info if needed for debugging
-                logging.debug(f"Full API response keys: {list(data.keys())}")
                 return []
 
             logging.info(f"Found {len(all_releases)} total releases from API")


### PR DESCRIPTION
🎯 **What:** Removed a `logging.debug` statement in `scraper_backends/graphql_backend.py` that logged the keys of the full API response when no releases were found.

⚠️ **Risk:** The API response might contain sensitive metadata or strings that should not be persisted in logs. Even logging just the keys can expose structural information about the backend or potentially sensitive field names.

🛡️ **Solution:** Completely removed the sensitive debug log and the associated warning comments. Validated the fix by running the GraphQL backend test suite with a mock runner to ensure no functional regressions.

---
*PR created automatically by Jules for task [17361004458151863686](https://jules.google.com/task/17361004458151863686) started by @damacus*