### PR TITLE
🧹 [Code Health] Remove unused get_allowed_tags method

### DIFF
--- a/scraper_backends/graphql_backend.py
+++ b/scraper_backends/graphql_backend.py
@@ -132,10 +132,6 @@ class GraphQLBackend:
                 response.raise_for_status()
                 return await response.json()
 
-    def get_allowed_tags(self) -> list[str]:
-        """Get the list of all allowed tags."""
-        return self.ALLOWED_TAGS.copy()
-
     def get_configured_tags(self) -> list[str]:
         """
         Get configured tags from TAGS environment variable.

--- a/tests/test_graphql_backend.py
+++ b/tests/test_graphql_backend.py
@@ -191,18 +191,6 @@ class TestGraphQLBackendTags(TestGraphQLBackendBase):
         # Should return empty list when no releases found
         self.assertEqual(results, [])
 
-    def test_get_allowed_tags_returns_complete_list(self) -> None:
-        """Test that get_allowed_tags returns the complete list of valid tags."""
-        backend = GraphQLBackend()
-        allowed_tags = backend.get_allowed_tags()
-
-        # Should include all 46 tags we discovered
-        self.assertEqual(len(allowed_tags), 46)
-        self.assertIn("unifi-protect", allowed_tags)
-        self.assertIn("unifi-network", allowed_tags)
-        self.assertIn("edgemax", allowed_tags)
-        self.assertIn("amplifi", allowed_tags)
-
 
 class TestGraphQLBackendFiltering(TestGraphQLBackendBase):
     """Test suite for GraphQL backend filtering functionality."""


### PR DESCRIPTION
🎯 What:
Removed the `get_allowed_tags` method from `scraper_backends/graphql_backend.py` and its corresponding test `test_get_allowed_tags_returns_complete_list` from `tests/test_graphql_backend.py`.

💡 Why:
The method was dead code. It was never called by the main application, and keeping dead code increases the maintenance burden and makes the codebase harder to read. Removing it simplifies the `GraphQLBackend` class.

✅ Verification:
Confirmed via grep that `get_allowed_tags` was only used in the test suite. Successfully ran all tests (`uv run python -m unittest discover tests/`) to ensure no regressions were introduced.

✨ Result:
Cleaner, more maintainable code without unused methods, while maintaining 100% test passing rate.

---
*PR created automatically by Jules for task [9073463279138878718](https://jules.google.com/task/9073463279138878718) started by @damacus*