### PR TITLE
🧹 Remove unused get_latest_release method

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -104,20 +104,6 @@ release = Release(
 
 #### Functions
 
-##### `async get_latest_release() -> Release | None`
-
-Fetches the latest release using the GraphQL backend.
-
-**Returns:**
-- `Release | None`: Release object if found, None if error occurs
-
-**Example:**
-```python
-release = await get_latest_release()
-if release:
-    print(f"Latest: {release.title}")
-```
-
 ##### `async get_latest_releases() -> list[Release]`
 
 Fetches the latest releases for all configured tags.
@@ -223,19 +209,6 @@ GraphQLBackend()
 
 **Methods:**
 
-###### `async get_latest_release() -> Release | None`
-
-Fetches the latest release for the first configured tag.
-
-**Returns:**
-- `Release | None`: Latest release or None if not found
-
-**Example:**
-```python
-backend = GraphQLBackend()
-release = await backend.get_latest_release()
-```
-
 ###### `async get_latest_releases() -> list[dict]`
 
 Fetches the latest releases for all configured tags.
@@ -260,36 +233,6 @@ Private method that fetches releases for a specific tag.
 
 **Returns:**
 - `dict | None`: Release dictionary or None if not found
-
----
-
-### scraper_backends/rss_backend.py
-
-RSS-based backend for fetching UniFi releases (legacy).
-
-#### Classes
-
-##### `RSSBackend`
-
-Scraper implementation using the Ubiquiti Community RSS feed.
-
-**Constructor:**
-```python
-RSSBackend()
-```
-
-**Methods:**
-
-###### `async get_latest_release() -> Release | None`
-
-Fetches the latest release from the RSS feed.
-
-**Returns:**
-- `Release | None`: Latest release or None if error occurs
-
-**Note:** The RSS backend does not support tag filtering and returns the absolute latest release regardless of product.
-
----
 
 ### release_parser.py
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -246,7 +246,7 @@ task test-cov
 uv run pytest tests/test_graphql_backend.py -v
 
 # Run specific test
-uv run pytest tests/test_graphql_backend.py::test_get_latest_release -v
+uv run pytest tests/test_graphql_backend.py::test_get_latest_releases -v
 ```
 
 ### Writing Tests
@@ -307,7 +307,7 @@ from scraper_interface import ScraperInterface
 class NewBackend(ScraperInterface):
     """New scraper backend implementation."""
     
-    def get_latest_release(self) -> dict:
+    async def get_latest_releases(self) -> list[dict]:
         """Fetch the latest release."""
         # Implementation
         pass
@@ -333,8 +333,8 @@ from scraper_backends.new_backend import NewBackend
 def test_new_backend():
     """Test new backend."""
     backend = NewBackend()
-    release = backend.get_latest_release()
-    assert release is not None
+    releases = await backend.get_latest_releases()
+    assert releases is not None
 ```
 
 ### Adding New Configuration Options

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -310,14 +310,11 @@ rm cache/release_state.json
 
 ### Test Scraper Backends
 
-You can test each backend independently:
+You can test the backend independently:
 
 ```bash
 # Test GraphQL backend
-uv run python -c "from scraper_backends.graphql_backend import GraphQLBackend; backend = GraphQLBackend(); print(backend.get_latest_release())"
-
-# Test RSS backend
-uv run python -c "from scraper_backends.rss_backend import RSSBackend; backend = RSSBackend(); print(backend.get_latest_release())"
+uv run python -c "import asyncio; from scraper_backends.graphql_backend import GraphQLBackend; backend = GraphQLBackend(); print(asyncio.run(backend.get_latest_releases()))"
 ```
 
 ### Verify Discord Bot Token

--- a/scraper_backends/graphql_backend.py
+++ b/scraper_backends/graphql_backend.py
@@ -203,9 +203,7 @@ class GraphQLBackend:
                 if tag not in release_tags:
                     continue
                 if not self._is_release_allowed_for_tag(release_title, tag):
-                    logging.debug(
-                        "Filtering out release '%s' for tag '%s'", release_data.get("title"), tag
-                    )
+                    logging.debug("Filtering out release '%s' for tag '%s'", release_data.get("title"), tag)
                     continue
                 existing = releases_by_tag.get(tag)
                 if existing is None or release_data["createdAt"] > existing["createdAt"]:
@@ -314,129 +312,6 @@ class GraphQLBackend:
         except Exception as e:
             logging.error(f"Error fetching latest releases: {type(e).__name__}")
             return []
-
-    async def get_latest_release(self) -> dict | None:
-        """
-        Get the latest UniFi Protect release using GraphQL API.
-
-        Returns:
-            Dict with title, url, and tag keys, or None if not found
-        """
-        try:
-            tags = self.get_configured_tags()
-
-            query = """
-            query ReleaseFeedListQuery(
-                $tags: [String!],
-                $betas: [String!],
-                $alphas: [String!],
-                $offset: Int,
-                $limit: Int,
-                $sortBy: ReleasesSortBy,
-                $userIsFollowing: Boolean,
-                $featuredOnly: Boolean,
-                $searchTerm: String,
-                $filterTags: [String!],
-                $filterEATags: [String!],
-                $statuses: [ReleaseStatus!]
-            ) {
-              releases(
-                tags: $tags
-                betas: $betas
-                alphas: $alphas
-                offset: $offset
-                limit: $limit
-                sortBy: $sortBy
-                userIsFollowing: $userIsFollowing
-                featuredOnly: $featuredOnly
-                searchTerm: $searchTerm
-                filterTags: $filterTags
-                filterEATags: $filterEATags
-                statuses: $statuses
-              ) {
-                pageInfo {
-                  offset
-                  limit
-                }
-                totalCount
-                items {
-                  id
-                  title
-                  slug
-                  tags
-                  betas
-                  alphas
-                  stage
-                  version
-                  userStatus {
-                    isFollowing
-                    lastViewedAt
-                  }
-                  author {
-                    id
-                    username
-                    isEmployee
-                    avatar {
-                      color
-                      content
-                      image
-                    }
-                  }
-                  createdAt
-                  lastActivityAt
-                  hasUiEngagement
-                  isLocked
-                  stats {
-                    comments
-                    views
-                  }
-                }
-              }
-            }
-            """
-
-            variables = {
-                "limit": 1,
-                "offset": 0,
-                "sortBy": "LATEST",
-                "tags": tags,
-                "betas": [],
-                "alphas": [],
-                "searchTerm": "",
-            }
-
-            payload = {"query": query, "variables": variables, "operationName": "ReleaseFeedListQuery"}
-
-            logging.info("Fetching latest UniFi Protect release")
-
-            data = await self._make_graphql_request(payload)
-
-            if "errors" in data:
-                error_msgs = [str(err.get("message", "")).replace("\n", " ") for err in data["errors"]]
-                logging.error(f"GraphQL errors: {error_msgs}")
-                return None
-
-            releases = data.get("data", {}).get("releases", {}).get("items", [])
-
-            if not releases:
-                logging.info("No releases found")
-                return None
-
-            latest = releases[0]
-            return {
-                "title": f"{latest['title']} {latest['version']}",
-                "url": f"https://community.ui.com/releases/{latest['slug']}/{latest['id']}",
-                "tag": "",
-            }
-
-        except aiohttp.ClientError as e:
-            # For ClientError, we can log the status if it exists, otherwise just the type
-            status = getattr(e, "status", "N/A")
-            logging.error(f"Network error fetching releases: {type(e).__name__} (status: {status})")
-            return None
-        except Exception as e:
-            logging.error(f"Unexpected error in GraphQL backend: {type(e).__name__}")
-            return None
 
     def _parse_release(self, release: dict) -> dict:
         """Parse a single release into structured format."""

--- a/scraper_interface.py
+++ b/scraper_interface.py
@@ -21,26 +21,6 @@ class Release:
     tag: str = ""  # Optional tag field for multi-tag support
 
 
-async def get_latest_release(session: aiohttp.ClientSession | None = None) -> Release | None:
-    """Get the latest release using GraphQL backend.
-
-    Args:
-        session: Optional aiohttp ClientSession for connection pooling
-
-    Returns:
-        Release object if found, None otherwise
-    """
-    try:
-        scraper = GraphQLBackend(session=session) if session else _backend
-        result = await scraper.get_latest_release()
-        if result is None:
-            return None
-        return Release(title=result["title"], url=result["url"], tag=result["tag"])
-    except Exception as e:
-        logging.error(f"Error fetching release: {e}")
-        return None
-
-
 async def get_latest_releases(session: aiohttp.ClientSession | None = None) -> list[Release]:
     """Get the latest releases for all configured tags using GraphQL backend.
 

--- a/tests/test_scraper_interface.py
+++ b/tests/test_scraper_interface.py
@@ -4,7 +4,7 @@ import asyncio
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from scraper_interface import Release, get_latest_release, get_latest_releases
+from scraper_interface import Release, get_latest_releases
 
 
 class TestScraperInterface(unittest.TestCase):
@@ -15,30 +15,6 @@ class TestScraperInterface(unittest.TestCase):
         release = Release(title="Test Release", url="https://example.com")
         self.assertEqual(release.title, "Test Release")
         self.assertEqual(release.url, "https://example.com")
-
-    @patch("scraper_interface._backend")
-    def test_get_latest_release_success(self, mock_backend: AsyncMock) -> None:
-        """Test get_latest_release returns release successfully."""
-        mock_backend.get_latest_release = AsyncMock(
-            return_value={"title": "Test Release", "url": "https://test.com", "tag": ""}
-        )
-
-        result = asyncio.run(get_latest_release())
-
-        mock_backend.get_latest_release.assert_called_once()
-        self.assertIsNotNone(result)
-        if result is not None:
-            self.assertEqual(result.title, "Test Release")
-            self.assertEqual(result.url, "https://test.com")
-
-    @patch("scraper_interface._backend")
-    def test_get_latest_release_handles_exception(self, mock_backend: AsyncMock) -> None:
-        """Test get_latest_release handles exceptions gracefully."""
-        mock_backend.get_latest_release = AsyncMock(side_effect=Exception("Backend error"))
-
-        result = asyncio.run(get_latest_release())
-
-        self.assertIsNone(result)
 
     @patch("scraper_interface._backend")
     def test_get_latest_releases_returns_list(self, mock_backend) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "unifi-release-announcer"
-version = "0.2.7"
+version = "0.2.10"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
🎯 **What:** Removed the unused `get_latest_release` method from `GraphQLBackend` and `scraper_interface`, along with its associated unit tests and documentation references. Also removed left-over documentation referencing the deleted `RSSBackend`.
💡 **Why:** `get_latest_release` is dead code not used anywhere in the application (the app relies on `get_latest_releases` exclusively). Removing it reduces maintenance burden and clutter.
✅ **Verification:** Ran `git grep` to ensure no usages exist, ran `uv run python -m unittest discover tests/`, and confirmed all checks pass.
✨ **Result:** A cleaner codebase and documentation.

---
*PR created automatically by Jules for task [456954648019978852](https://jules.google.com/task/456954648019978852) started by @damacus*