### PR TITLE
🧪 [testing improvement] Add test coverage for AnnouncerClient.close

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -332,5 +332,31 @@ class TestCheckForUpdates(unittest.IsolatedAsyncioTestCase):
         mock_process.assert_any_await(releases[2])
 
 
+class TestAnnouncerClient(unittest.IsolatedAsyncioTestCase):
+    """Test suite for AnnouncerClient."""
+
+    @patch("discord.Client.close", new_callable=AsyncMock)
+    async def test_close_without_session(self, mock_super_close) -> None:
+        intents = discord.Intents.default()
+        client = main.AnnouncerClient(intents=intents)
+        self.assertIsNone(client.session)
+
+        await client.close()
+
+        mock_super_close.assert_awaited_once()
+
+    @patch("discord.Client.close", new_callable=AsyncMock)
+    async def test_close_with_session(self, mock_super_close) -> None:
+        intents = discord.Intents.default()
+        client = main.AnnouncerClient(intents=intents)
+        mock_session = AsyncMock()
+        client.session = mock_session
+
+        await client.close()
+
+        mock_session.close.assert_awaited_once()
+        mock_super_close.assert_awaited_once()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for `AnnouncerClient.close` in `main.py`
📊 **Coverage:** Covered both scenarios where a session is configured (`test_close_with_session`) and where no session exists (`test_close_without_session`), successfully awaiting `super().close()` and conditionally awaiting `session.close()`.
✨ **Result:** Improved test coverage, adding the `TestAnnouncerClient` test suite ensuring proper cleanup execution in `AnnouncerClient.close`

---
*PR created automatically by Jules for task [11081257478290055975](https://jules.google.com/task/11081257478290055975) started by @damacus*