### PR TITLE
🧪 Add test for before_check task pre-hook

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -253,6 +253,12 @@ class TestProcessNewRelease(unittest.IsolatedAsyncioTestCase):
 class TestCheckForUpdates(unittest.IsolatedAsyncioTestCase):
     """Test suite for the check_for_updates background task."""
 
+    async def test_before_check_awaits_ready(self) -> None:
+        """Test that before_check waits for the client to be ready."""
+        with patch.object(main.client, "wait_until_ready", new_callable=AsyncMock) as mock_wait:
+            await main.before_check()
+            mock_wait.assert_awaited_once()
+
     @patch("main.DISCORD_CHANNEL_ID", None)
     @patch("main.get_latest_releases", new_callable=AsyncMock)
     async def test_skips_when_channel_id_not_set(self, mock_get_releases) -> None:


### PR DESCRIPTION
🎯 **What:** The `before_check` pre-hook inside `main.py` lacked test coverage, despite being extremely simple to test.
📊 **Coverage:** A new test `test_before_check_awaits_ready` was added which correctly asserts that the client initialization block is correctly executed by awaiting `client.wait_until_ready` during the background task startup.
✨ **Result:** Enhanced test coverage providing a safer environment for continuous application delivery and lifecycle refactoring.

---
*PR created automatically by Jules for task [7595366437351384126](https://jules.google.com/task/7595366437351384126) started by @damacus*